### PR TITLE
Remove SessionInterface dependency for Symfony 5.3

### DIFF
--- a/src/Provider/SessionTimeProvider.php
+++ b/src/Provider/SessionTimeProvider.php
@@ -15,25 +15,25 @@ namespace Nucleos\AntiSpamBundle\Provider;
 
 use DateTime;
 use DateTimeImmutable;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 final class SessionTimeProvider implements TimeProviderInterface
 {
     /**
-     * @var Session
+     * @var RequestStack
      */
-    private $session;
+    private $requestStack;
 
-    public function __construct(Session $session)
+    public function __construct(RequestStack $requestStack)
     {
-        $this->session = $session;
+        $this->requestStack = $requestStack;
     }
 
     public function createFormProtection(string $name): void
     {
         $startTime = new DateTime();
         $key       = $this->getSessionKey($name);
-        $this->session->set($key, $startTime);
+        $this->requestStack->getSession()->set($key, $startTime);
     }
 
     public function isValid(string $name, array $options): bool
@@ -60,7 +60,7 @@ final class SessionTimeProvider implements TimeProviderInterface
     public function removeFormProtection(string $name): void
     {
         $key = $this->getSessionKey($name);
-        $this->session->remove($key);
+        $this->requestStack->getSession()->remove($key);
     }
 
     /**
@@ -70,7 +70,7 @@ final class SessionTimeProvider implements TimeProviderInterface
     {
         $key = $this->getSessionKey($name);
 
-        return $this->session->has($key);
+        return $this->requestStack->getSession()->has($key);
     }
 
     /**
@@ -83,7 +83,7 @@ final class SessionTimeProvider implements TimeProviderInterface
         $key = $this->getSessionKey($name);
 
         if ($this->hasFormProtection($name)) {
-            return $this->session->get($key);
+            return $this->requestStack->getSession()->get($key);
         }
 
         return null;

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -33,7 +33,7 @@ return static function (ContainerConfigurator $container): void {
 
         ->set('nucleos_antispam.provider.session', SessionTimeProvider::class)
             ->args([
-                new Reference('session'),
+                new Reference('request_stack'),
                 [],
             ])
 

--- a/tests/Provider/SessionTimeProviderTest.php
+++ b/tests/Provider/SessionTimeProviderTest.php
@@ -32,16 +32,18 @@ final class SessionTimeProviderTest extends TestCase
         $session->set('antispam_foobar', Argument::type(DateTime::class))
             ->shouldBeCalled()
         ;
-
-        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
+        /** @var RequestStack $stack */
+        $stack = $this->createStack($session)->reveal();
+        $provider = new SessionTimeProvider($stack);
         $provider->createFormProtection('foobar');
     }
 
     public function testIsValid(): void
     {
         $session  = $this->prepareValidSessionKey();
-
-        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
+        /** @var RequestStack $stack */
+        $stack = $this->createStack($session)->reveal();
+        $provider = new SessionTimeProvider($stack);
 
         static::assertTrue($provider->isValid('foobar', []));
     }
@@ -49,8 +51,9 @@ final class SessionTimeProviderTest extends TestCase
     public function testIsValidWithMinTime(): void
     {
         $session  = $this->prepareValidSessionKey();
-
-        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
+        /** @var RequestStack $stack */
+        $stack = $this->createStack($session)->reveal();
+        $provider = new SessionTimeProvider($stack);
 
         static::assertTrue($provider->isValid('foobar', [
             'min' => 10,
@@ -60,8 +63,9 @@ final class SessionTimeProviderTest extends TestCase
     public function testIsValidWithMaxTime(): void
     {
         $session  = $this->prepareValidSessionKey();
-
-        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
+        /** @var RequestStack $stack */
+        $stack = $this->createStack($session)->reveal();
+        $provider = new SessionTimeProvider($stack);
 
         static::assertTrue($provider->isValid('foobar', [
             'max' => 60,
@@ -74,8 +78,9 @@ final class SessionTimeProviderTest extends TestCase
         $session->has('antispam_foobar')
             ->willReturn(false)
         ;
-
-        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
+        /** @var RequestStack $stack */
+        $stack = $this->createStack($session)->reveal();
+        $provider = new SessionTimeProvider($stack);
 
         static::assertFalse($provider->isValid('foobar', []));
     }
@@ -83,8 +88,9 @@ final class SessionTimeProviderTest extends TestCase
     public function testIsInvalidBecauseOfMinTime(): void
     {
         $session  = $this->prepareValidSessionKey();
-
-        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
+        /** @var RequestStack $stack */
+        $stack = $this->createStack($session)->reveal();
+        $provider = new SessionTimeProvider($stack);
         static::assertFalse($provider->isValid('foobar', [
             'min' => 60,
         ]));
@@ -92,8 +98,10 @@ final class SessionTimeProviderTest extends TestCase
 
     public function testIsInvalidBecauseOfMaxTime(): void
     {
-        $session  = $this->prepareValidSessionKey();
-        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
+        $session  = $this->prepareValidSessionKey()
+        /** @var RequestStack $stack */
+        $stack = $this->createStack($session)->reveal();
+        $provider = new SessionTimeProvider($stack);
 
         static::assertFalse($provider->isValid('foobar', [
             'max' => 10,
@@ -106,8 +114,9 @@ final class SessionTimeProviderTest extends TestCase
         $session->remove('antispam_foobar')
             ->shouldBeCalled()
         ;
-
-        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
+        /** @var RequestStack $stack */
+        $stack = $this->createStack($session)->reveal();
+        $provider = new SessionTimeProvider($stack);
         $provider->removeFormProtection('foobar');
     }
 
@@ -131,6 +140,7 @@ final class SessionTimeProviderTest extends TestCase
     {
         $stack = $this->prophesize(RequestStack::class);
         $stack->getSession()->willReturn($session->reveal());
+        
         return $stack;
     }
 }

--- a/tests/Provider/SessionTimeProviderTest.php
+++ b/tests/Provider/SessionTimeProviderTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 final class SessionTimeProviderTest extends TestCase
@@ -32,7 +33,7 @@ final class SessionTimeProviderTest extends TestCase
             ->shouldBeCalled()
         ;
 
-        $provider = new SessionTimeProvider($session->reveal());
+        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
         $provider->createFormProtection('foobar');
     }
 
@@ -40,7 +41,7 @@ final class SessionTimeProviderTest extends TestCase
     {
         $session  = $this->prepareValidSessionKey();
 
-        $provider = new SessionTimeProvider($session->reveal());
+        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
 
         static::assertTrue($provider->isValid('foobar', []));
     }
@@ -49,7 +50,7 @@ final class SessionTimeProviderTest extends TestCase
     {
         $session  = $this->prepareValidSessionKey();
 
-        $provider = new SessionTimeProvider($session->reveal());
+        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
 
         static::assertTrue($provider->isValid('foobar', [
             'min' => 10,
@@ -60,7 +61,7 @@ final class SessionTimeProviderTest extends TestCase
     {
         $session  = $this->prepareValidSessionKey();
 
-        $provider = new SessionTimeProvider($session->reveal());
+        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
 
         static::assertTrue($provider->isValid('foobar', [
             'max' => 60,
@@ -74,7 +75,7 @@ final class SessionTimeProviderTest extends TestCase
             ->willReturn(false)
         ;
 
-        $provider = new SessionTimeProvider($session->reveal());
+        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
 
         static::assertFalse($provider->isValid('foobar', []));
     }
@@ -83,7 +84,7 @@ final class SessionTimeProviderTest extends TestCase
     {
         $session  = $this->prepareValidSessionKey();
 
-        $provider = new SessionTimeProvider($session->reveal());
+        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
         static::assertFalse($provider->isValid('foobar', [
             'min' => 60,
         ]));
@@ -92,7 +93,7 @@ final class SessionTimeProviderTest extends TestCase
     public function testIsInvalidBecauseOfMaxTime(): void
     {
         $session  = $this->prepareValidSessionKey();
-        $provider = new SessionTimeProvider($session->reveal());
+        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
 
         static::assertFalse($provider->isValid('foobar', [
             'max' => 10,
@@ -106,7 +107,7 @@ final class SessionTimeProviderTest extends TestCase
             ->shouldBeCalled()
         ;
 
-        $provider = new SessionTimeProvider($session->reveal());
+        $provider = new SessionTimeProvider($this->createStack($session)->reveal());
         $provider->removeFormProtection('foobar');
     }
 
@@ -124,5 +125,12 @@ final class SessionTimeProviderTest extends TestCase
         ;
 
         return $session;
+    }
+
+    private function createStack(ObjectProphecy $session): ObjectProphecy
+    {
+        $stack = $this->prophesize(RequestStack::class);
+        $stack->getSession()->willReturn($session->reveal());
+        return $stack;
     }
 }


### PR DESCRIPTION
## Subject

Symfony 5.3 deprecates the use of SessionInterface and the session service alias https://symfony.com/blog/new-in-symfony-5-3-session-service-deprecation. 
This PR fix this compatibility 
