### PR TITLE
Fix issue with time protection

### DIFF
--- a/src/Form/EventListener/AntiSpamTimeListener.php
+++ b/src/Form/EventListener/AntiSpamTimeListener.php
@@ -59,6 +59,7 @@ final class AntiSpamTimeListener implements EventSubscriberInterface
     {
         return [
             FormEvents::PRE_SUBMIT => 'preSubmit',
+            FormEvents::POST_SUBMIT => 'postSubmit',
         ];
     }
 

--- a/src/Form/EventListener/AntiSpamTimeListener.php
+++ b/src/Form/EventListener/AntiSpamTimeListener.php
@@ -18,6 +18,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class AntiSpamTimeListener implements EventSubscriberInterface
@@ -65,7 +66,7 @@ final class AntiSpamTimeListener implements EventSubscriberInterface
     {
         $form = $event->getForm();
 
-        if (!$form->isRoot() || null === $form->getConfig()->getOption('compound')) {
+        if (!$this->isApplicableToForm($form)) {
             return;
         }
 
@@ -76,5 +77,24 @@ final class AntiSpamTimeListener implements EventSubscriberInterface
 
         // Remove old entry
         $this->timeProvider->removeFormProtection($form->getName());
+    }
+
+    private function isApplicableToForm(FormInterface $form): bool
+    {
+        return $form->isRoot() && null !== $form->getConfig()->getOption('compound');
+    }
+
+    public function postSubmit(FormEvent $event): void
+    {
+        $form = $event->getForm();
+
+        if (!$this->isApplicableToForm($form)) {
+            return;
+        }
+
+        // If form has errors, set the time again
+        if (!$form->isValid()) {
+            $this->timeProvider->createFormProtection($form->getName());
+        }
     }
 }


### PR DESCRIPTION
Fix issue with time protection that prevents form re-submitting after validation errors

## Subject

If the form is submitted and there are some validation errors, the time protection prevents submitting it again after fixing the form values. It would give a time error even though the form is submitted within the min and max seconds.

This change is adding the start time again on POST_SUBMIT if error is not valid.
