### PR TITLE
Use deterministic mail replacement.

### DIFF
--- a/src/Twig/Extension/StringTwigExtension.php
+++ b/src/Twig/Extension/StringTwigExtension.php
@@ -75,10 +75,10 @@ final class StringTwigExtension extends AbstractExtension
      */
     private function encryptMailText(array $matches): string
     {
-        $email = $matches[1];
+        [$original, $email] = $matches;
 
         return $this->getSecuredName($email).
-            $this->mailAtText[array_rand($this->mailAtText)].
+            $this->hashedArrayValue($this->mailAtText, $original).
             $this->getSecuredName($email, true);
     }
 
@@ -87,7 +87,7 @@ final class StringTwigExtension extends AbstractExtension
      */
     private function encryptMail(array $matches): string
     {
-        [, $email, $text] = $matches;
+        [$original, $email, $text] = $matches;
 
         if ($text === $email) {
             $text = '';
@@ -96,7 +96,7 @@ final class StringTwigExtension extends AbstractExtension
         return
             '<span'.(null !== $this->mailCssClass ? ' class="'.$this->mailCssClass.'"' : '').'>'.
             '<span>'.$this->getSecuredName($email).'</span>'.
-                $this->mailAtText[array_rand($this->mailAtText)].
+                $this->hashedArrayValue($this->mailAtText, $original).
             '<span>'.$this->getSecuredName($email, true).'</span>'.
             ('' !== $text ? ' (<span>'.$text.'</span>)' : '').
             '</span>';
@@ -114,6 +114,24 @@ final class StringTwigExtension extends AbstractExtension
             $name = substr($name, 0, $index);
         }
 
-        return str_replace('.', $this->mailDotText[array_rand($this->mailDotText)], $name);
+        return str_replace('.', $this->hashedArrayValue($this->mailDotText, $name), $name);
+    }
+
+    /**
+     * @param string[] $list
+     */
+    private function hashedArrayValue(array $list, string $name): string
+    {
+        $count = \count($list);
+        $index = $this->numericHash($name) % $count;
+
+        return $list[$index];
+    }
+
+    private function numericHash(string $name): int
+    {
+        $hash = hash('sha256', $name);
+
+        return \intval(substr($hash, 0, 6), 16);
     }
 }

--- a/tests/Twig/Extension/StringTwigExtensionTest.php
+++ b/tests/Twig/Extension/StringTwigExtensionTest.php
@@ -21,7 +21,7 @@ final class StringTwigExtensionTest extends TestCase
 {
     public function testGetFilters(): void
     {
-        $extension = new StringTwigExtension('spam', ['[AT]'], ['[DOT]']);
+        $extension = new StringTwigExtension('spam', ['[AT]', '[ÄT]', '(AT)', '|AT|'], ['[DOT]', ' PUNKT ', '[.]']);
 
         $filters = $extension->getFilters();
 
@@ -38,7 +38,7 @@ final class StringTwigExtensionTest extends TestCase
      */
     public function testAntispam(string $input, string $output): void
     {
-        $extension = new StringTwigExtension('spam', ['[AT]'], ['[DOT]']);
+        $extension = new StringTwigExtension('spam', ['[AT]', '[ÄT]', '(AT)', '|AT|'], ['[DOT]', ' PUNKT ', '[.]']);
 
         static::assertSame($output, $extension->antispam($input));
     }
@@ -48,7 +48,7 @@ final class StringTwigExtensionTest extends TestCase
      */
     public function testAntispamText(string $input, string $output): void
     {
-        $extension = new StringTwigExtension('spam', ['[AT]'], ['[DOT]']);
+        $extension = new StringTwigExtension('spam', ['[AT]', '[ÄT]', '(AT)', '|AT|'], ['[DOT]', ' PUNKT ', '[.]']);
 
         static::assertSame($output, $extension->antispam($input, false));
     }
@@ -61,22 +61,17 @@ final class StringTwigExtensionTest extends TestCase
                 'Lorem Ipsum <script>const link = "foo@bar.baz"; </script> Sit Amet',
                 'Lorem Ipsum <script>const link = "foo@bar.baz"; </script> Sit Amet',
             ],
-            // TODO: Replace plain mails text in html
-            //            [
-            //                'Lorem Ipsum foo.sub@bar.baz.tld Sit Amet',
-            //                'Lorem Ipsum <span class="spam"><span>foo[DOT]sub</span>[AT]<span>bar[DOT]baz[DOT]tld</span></span> Sit Amet',
-            //            ],
             [
                 'Lorem Ipsum <a href="mailto:john@smith.cool">John Smith</a> Sit Amet',
-                'Lorem Ipsum <span class="spam"><span>john</span>[AT]<span>smith[DOT]cool</span> (<span>John Smith</span>)</span> Sit Amet',
+                'Lorem Ipsum <span class="spam"><span>john</span>[AT]<span>smith[.]cool</span> (<span>John Smith</span>)</span> Sit Amet',
             ],
             [
                 'Lorem Ipsum <a href="mailto:foo.sub@bar.baz.tld">foo.sub@bar.baz.tld</a> Sit Amet',
-                'Lorem Ipsum <span class="spam"><span>foo[DOT]sub</span>[AT]<span>bar[DOT]baz[DOT]tld</span></span> Sit Amet',
+                'Lorem Ipsum <span class="spam"><span>foo[DOT]sub</span>(AT)<span>bar PUNKT baz PUNKT tld</span></span> Sit Amet',
             ],
             [
-                'Lorem Ipsum <span class="spam"><span>foo[DOT]sub</span>[AT]<span>bar[DOT]baz[DOT]tld</span></span> Sit Amet',
-                'Lorem Ipsum <span class="spam"><span>foo[DOT]sub</span>[AT]<span>bar[DOT]baz[DOT]tld</span></span> Sit Amet',
+                'Lorem Ipsum <span class="spam"><span>foo[DOT]sub</span>(AT)<span>bar PUNKT baz PUNKT tld</span></span> Sit Amet',
+                'Lorem Ipsum <span class="spam"><span>foo[DOT]sub</span>(AT)<span>bar PUNKT baz PUNKT tld</span></span> Sit Amet',
             ],
         ];
     }
@@ -89,11 +84,11 @@ final class StringTwigExtensionTest extends TestCase
         return [
             [
                 'Lorem Ipsum foo.sub@bar.baz.tld Sit Amet',
-                'Lorem Ipsum foo[DOT]sub[AT]bar[DOT]baz[DOT]tld Sit Amet',
+                'Lorem Ipsum foo[DOT]sub[AT]bar PUNKT baz PUNKT tld Sit Amet',
             ],
             [
-                'Lorem Ipsum foo[DOT]sub[AT]bar[DOT]baz[DOT]tld Sit Amet',
-                'Lorem Ipsum foo[DOT]sub[AT]bar[DOT]baz[DOT]tld Sit Amet',
+                'Lorem Ipsum foo[DOT]sub[AT]bar PUNKT baz PUNKT tld Sit Amet',
+                'Lorem Ipsum foo[DOT]sub[AT]bar PUNKT baz PUNKT tld Sit Amet',
             ],
         ];
     }


### PR DESCRIPTION
In order to prevent detection of obfuscated emails, the replacement should be deterministic. 

Reloading a page will now use the same email obfuscation.